### PR TITLE
Removed "member" media attachment type (#247)

### DIFF
--- a/telega-chat.el
+++ b/telega-chat.el
@@ -3403,12 +3403,6 @@ Uses `telega-screenshot-function' to take a screenshot."
         (x-focus-frame (window-frame (get-buffer-window)))
         (telega-chatbuf--attach-tmp-photo tmpfile)))))
 
-(defun telega-chatbuf-attach-member (user)
-  "Add USER to the chat members."
-  (interactive (list (telega-completing-read-user "Add member: ")))
-  (cl-assert user)
-  (telega-chat-add-member telega-chatbuf--chat user))
-
 (defun telega-chatbuf-sticker-insert (sticker)
   "Attach STICKER to the input."
   (let ((thumb (plist-get sticker :thumbnail))

--- a/telega-customize.el
+++ b/telega-customize.el
@@ -978,7 +978,6 @@ different days. Such as:
               (not (telega-chat-private-p telega-chatbuf--chat)))
      telega-chatbuf-attach-poll)
     ("contact" nil telega-chatbuf-attach-contact)
-    ("member" nil telega-chatbuf-attach-member)
     ("sticker" nil telega-chatbuf-attach-sticker)
     ("animation" nil telega-chatbuf-attach-animation)
     ("dice" nil telega-chatbuf-attach-dice)


### PR DESCRIPTION
* Removed "member" media attachment type, use `telega-chat-add-member` command to add chat members